### PR TITLE
ID-475 upgrading retrofit and guava to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <!-- Default when no revision property is passed in from the commandline -->
         <revision>local-SNAPSHOT</revision>
         <scm.plugin-tag>v${project.version}</scm.plugin-tag>
-	    <version.retrofit>2.1.0</version.retrofit>
+        <version.retrofit>2.7.1</version.retrofit>
     </properties>
 
     <build>
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Our current version of Retrofit is showing up as having a security vulnerability in whitesource.  This increase to the latest/best version should mitigate that security hole.